### PR TITLE
Support for GNOME Shell 43

### DIFF
--- a/metadata.json.in
+++ b/metadata.json.in
@@ -2,7 +2,7 @@
   "name": "%_NAME_%",
   "description": "Customize the date and time format displayed in clock in the top bar in GNOME Shell. Add as much or as little time information you want with extensive formatting options including an emoji clock face and Internet Time (.beat).",
   "shell-version": [
-    "40"
+    "43"
   ],
   "settings-schema": "org.gnome.shell.extensions.clock-override",
   "url": "https://github.com/stuartlangridge/gnome-shell-clock-override",

--- a/prefs.js
+++ b/prefs.js
@@ -69,7 +69,7 @@ const ClockOverrideSettings = new GObject.Class({
         this.attach(label2, 0, 1, 3, 1);
 
         var css = new Gtk.CssProvider();
-        css.load_from_data("GtkLabel { text-decoration: underline rgba(128, 128, 128, 0.3); }");
+        css.load_from_data("GtkLabel { text-decoration: underline rgba(128, 128, 128, 0.3); }", -1);
 
         var grid = this;
         var rownumber = 2;


### PR DESCRIPTION
Recently I switched from ZorinOS 16.3 to 17 (means Ubuntu20.04 to 22.04) and noticed the extension wasnot working. I made the change based on the gnome-40 branch (thank you, sluedecke).
Zorin OS17 uses Gnome Shell 43.9 (as of today). This change should work for Gnome 43 (and later versions).
